### PR TITLE
require pycddlib<3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pwasopt"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
   { name="Mengjia Zhu", email="mengjia.zhu@imtlucca.it" },
   { name="Alberto Bemporad", email="alberto.bemporad@imtlucca.it" },
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
     "numpy>=1.24.3","scipy>=1.11.1","pulp>=2.8.0","pyDOE>=0.3.8","scikit-learn>=1.3.0",
-    "pycddlib>=2.1.7","pyparc>=2.0.4", "threadpoolctl>=3.1.0"]
+    "pycddlib>=2.1.7,<3.0.0","pyparc>=2.0.4", "threadpoolctl>=3.1.0"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Pycddlib is getting a big revamp to properly support type hints, and as a result the API is going to change quite a bit. To prevent users installing your package to experience problems, I suggest explicitly specifying pycddlib<3.0.0 in dependencies now, prior to pycddlib getting its new release out of beta, until PWAS has migrated to the new pycddlib API.

More info here: https://pycddlib.readthedocs.io/en/latest/changes.html